### PR TITLE
fix rpc cors setting for miner config

### DIFF
--- a/miner.toml
+++ b/miner.toml
@@ -13,7 +13,7 @@ reserved_peers = "./network.txt"
 disable = false
 port = 8545
 apis = ["all"]
-cors = ["*"]
+cors = "*"
 hosts = ["all"]
 interface = "all"
 


### PR DESCRIPTION
Running `$ ./start` gave the error:
```
invalid type: sequence, expected a string for key `rpc.cors`
```
Fixes that.