### PR TITLE
No LoadBalancer supports combined protocols on one port

### DIFF
--- a/k8s/testnet/ethereum.yaml
+++ b/k8s/testnet/ethereum.yaml
@@ -15,9 +15,6 @@ spec:
     - name: listening
       protocol: TCP
       port: 30303
-    - name: discovery
-      protocol: UDP
-      port: 30303
   type: LoadBalancer
 ---
 apiVersion: v1


### PR DESCRIPTION
newer versions of k8s will reject this config since it is not supported
and since it hasn't been working, seems like it's not needed