### PR TITLE
We should have the loadBalancer map 6688 to port 80

### DIFF
--- a/k8s/testnet/chainlink.yaml
+++ b/k8s/testnet/chainlink.yaml
@@ -8,10 +8,8 @@ spec:
   ports:
     - name: cl
       protocol: TCP
-      port: 6688
-    - name: gui
-      protocol: TCP
-      port: 6689
+      port: 80
+      targetPort: 6688
   type: LoadBalancer
 ---
 apiVersion: v1
@@ -46,7 +44,6 @@ spec:
           args: ["node", "--password", "/secrets/.password"]
           ports:
             - containerPort: 6688
-            - containerPort: 6689
           env:
             - name: ROOT
               value: "/data/chainlink"


### PR DESCRIPTION
If https://github.com/smartcontractkit/chainlink/pull/403 is accepted, then we can map 80 to 6688 and forget about having to manually specify ports in the browser.