### PR TITLE
Release: St Peters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM parity/parity:v2.2.11
+FROM parity/parity:v2.7.2-stable
 COPY . /devnet
 USER root
 RUN chown -R parity /devnet

--- a/smartNet.json
+++ b/smartNet.json
@@ -17,12 +17,21 @@
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
     "networkID" : "0x8507",
-    "eip155Transition": 0,
-    "validateChainIdTransition": 0,
-    "eip140Transition": 0,
-    "eip211Transition": 0,
-    "eip214Transition": 0,
-    "eip658Transition": 0
+    "validateChainIdTransition": "0x0",
+    "eip150Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip140Transition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "eip155Transition": "0x0",
+    "eip658Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0"
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
Pulls the updated chain parameters from [Parity's St Peters test environment](https://github.com/paritytech/parity-ethereum/blob/283d0773fe2014810600cd3dea58f09d89f959de/ethcore/res/ethereum/st_peters_test.json).