### PR TITLE
Raise gas limit

### DIFF
--- a/smartNet.json
+++ b/smartNet.json
@@ -41,7 +41,7 @@
       }
     },
     "difficulty": "0x20000",
-    "gasLimit": "0x5B8D80"
+    "gasLimit": "0x6ACFC0"
   },
   "accounts": {
     "0x0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },


### PR DESCRIPTION
Integration tests regularly fail on parity when deploying the FluxAggregator contract

```bash
# parity error
Transaction cost exceeds current gas limit. Limit: 6017591, got: 6052600.
Try decreasing supplied gas.
```

This PR bumps the per-tx gas limit from 6000000 wei to 7000000 wei.