### PR TITLE
Enable force-sealing option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 RUN chown -R parity /devnet
 USER parity
 WORKDIR /devnet
-CMD ["--config", "/devnet/miner.toml"]
+CMD ["--force-sealing", "--config", "/devnet/miner.toml"]
 
 EXPOSE 8546
 EXPOSE 8545


### PR DESCRIPTION
According to Parity docs:

The consensus can be run with --force-sealing which ensures that blocks are produced even if there are no transactions. This is necessary for blocks to reach finality in a timely fashion.

https://openethereum.github.io/wiki/Aura